### PR TITLE
docs: 内部リンク統一とパンくず統一（Phase #33/#27）

### DIFF
--- a/docs/_includes/breadcrumb.html
+++ b/docs/_includes/breadcrumb.html
@@ -1,204 +1,114 @@
 <!-- Breadcrumb Navigation -->
-<ol class="breadcrumb-list" vocab="https://schema.org/" typeof="BreadcrumbList">
+{% assign url_parts = page.url | split: '/' | compact %}
+{% assign breadcrumb_url = '' %}
+
+<ol class="breadcrumb-list">
     <!-- Home -->
-    <li property="itemListElement" typeof="ListItem">
-        <a property="item" typeof="WebPage" href="{{ '/' | relative_url }}">
-            <span property="name">
-                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="breadcrumb-home-icon">
-                    <path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"></path>
-                    <polyline points="9,22 9,12 15,12 15,22"></polyline>
-                </svg>
-                ホーム
-            </span>
+    <li class="breadcrumb-item">
+        <a href="{{ '/' | relative_url }}" class="breadcrumb-link">
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                <path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"></path>
+                <polyline points="9 22 9 12 15 12 15 22"></polyline>
+            </svg>
+            <span class="sr-only">ホーム</span>
         </a>
-        <meta property="position" content="1">
     </li>
-    
-    <!-- Section (Introduction/Chapters/Appendices) -->
-    {% if page.url contains '/introduction/' %}
-        <li property="itemListElement" typeof="ListItem">
-            <span class="breadcrumb-separator" aria-hidden="true">›</span>
-            <span property="name">はじめに</span>
-            <meta property="position" content="2">
-        </li>
-    {% elsif page.url contains '/chapters/' %}
-        <li property="itemListElement" typeof="ListItem">
-            <span class="breadcrumb-separator" aria-hidden="true">›</span>
-            <span property="name">章</span>
-            <meta property="position" content="2">
-        </li>
-        
-        <!-- Specific Chapter -->
-        {% for chapter in site.data.navigation.chapters %}
-            {% if page.url contains chapter.path %}
-                <li property="itemListElement" typeof="ListItem">
-                    <span class="breadcrumb-separator" aria-hidden="true">›</span>
-                    <a property="item" typeof="WebPage" href="{{ site.baseurl }}{{ chapter.path }}">
-                        <span property="name">{{ chapter.title }}</span>
-                    </a>
-                    <meta property="position" content="3">
+
+    <!-- Build breadcrumb from URL parts -->
+    {% for part in url_parts %}
+        {% unless part == '' %}
+            {% assign breadcrumb_url = breadcrumb_url | append: '/' | append: part %}
+            
+            {% if forloop.last %}
+                <!-- Current page (last item) -->
+                <li class="breadcrumb-item active" aria-current="page">
+                    {{ page.title | default: part | replace: '-', ' ' | capitalize }}
                 </li>
-                {% break %}
-            {% endif %}
-        {% endfor %}
-    {% elsif page.url contains '/appendices/' %}
-        <li property="itemListElement" typeof="ListItem">
-            <span class="breadcrumb-separator" aria-hidden="true">›</span>
-            <span property="name">付録</span>
-            <meta property="position" content="2">
-        </li>
-        
-        <!-- Specific Appendix -->
-        {% for appendix in site.data.navigation.appendices %}
-            {% if page.url contains appendix.path %}
-                <li property="itemListElement" typeof="ListItem">
-                    <span class="breadcrumb-separator" aria-hidden="true">›</span>
-                    <a property="item" typeof="WebPage" href="{{ site.baseurl }}{{ appendix.path }}">
-                        <span property="name">{{ appendix.title }}</span>
+            {% else %}
+                <!-- Parent pages -->
+                <li class="breadcrumb-item">
+                    {% comment %} Try to find a matching page for better titles {% endcomment %}
+                    {% assign parent_page = nil %}
+                    {% for p in site.pages %}
+                        {% if p.url == breadcrumb_url or p.url == breadcrumb_url | append: '/' or p.url == breadcrumb_url | append: '/index.html' %}
+                            {% assign parent_page = p %}
+                            {% break %}
+                        {% endif %}
+                    {% endfor %}
+                    
+                    <a href="{{ breadcrumb_url | relative_url }}" class="breadcrumb-link">
+                        {% if parent_page %}
+                            {{ parent_page.title }}
+                        {% else %}
+                            {{ part | replace: '-', ' ' | capitalize }}
+                        {% endif %}
                     </a>
-                    <meta property="position" content="3">
                 </li>
-                {% break %}
             {% endif %}
-        {% endfor %}
-    {% endif %}
-    
-    <!-- Current Page (if different from section) -->
-    {% unless page.url == '/' %}
-        {% assign is_section_page = false %}
-        {% if page.url contains '/chapters/' %}
-            {% for chapter in site.data.navigation.chapters %}
-                {% if page.url == chapter.path %}
-                    {% assign is_section_page = true %}
-                    {% break %}
-                {% endif %}
-            {% endfor %}
-        {% elsif page.url contains '/appendices/' %}
-            {% for appendix in site.data.navigation.appendices %}
-                {% if page.url == appendix.path %}
-                    {% assign is_section_page = true %}
-                    {% break %}
-                {% endif %}
-            {% endfor %}
-        {% elsif page.url contains '/introduction/' %}
-            {% assign is_section_page = true %}
-        {% endif %}
-        
-        {% unless is_section_page %}
-        <li property="itemListElement" typeof="ListItem">
-            <span class="breadcrumb-separator" aria-hidden="true">›</span>
-            <span property="name" class="breadcrumb-current">{{ page.title | default: "現在のページ" }}</span>
-            <meta property="position" content="4">
-        </li>
         {% endunless %}
-    {% endunless %}
+    {% endfor %}
 </ol>
 
 <style>
-/* Breadcrumb Styles */
 .breadcrumb-list {
     display: flex;
-    flex-wrap: wrap;
     align-items: center;
     list-style: none;
-    margin: 0 0 var(--space-6) 0;
-    padding: var(--space-3) 0;
-    font-size: var(--font-size-sm);
-    color: var(--color-text-secondary);
-    border-bottom: 1px solid var(--color-border-light);
+    padding: 0;
+    margin: 0 0 1.5rem 0;
+    font-size: 0.875rem;
+    flex-wrap: wrap;
 }
 
-.breadcrumb-list li {
+.breadcrumb-item {
     display: flex;
     align-items: center;
-    margin: 0;
 }
 
-.breadcrumb-list a {
-    color: var(--color-text-secondary);
+.breadcrumb-item:not(:last-child)::after {
+    content: '/';
+    margin: 0 0.5rem;
+    color: var(--text-muted);
+}
+
+.breadcrumb-link {
+    color: var(--text-secondary);
     text-decoration: none;
-    transition: color var(--transition-fast);
+    transition: color 0.2s ease;
     display: flex;
     align-items: center;
-    padding: var(--space-1) var(--space-2);
-    border-radius: var(--radius-sm);
+    gap: 0.25rem;
 }
 
-.breadcrumb-list a:hover {
-    color: var(--color-primary);
-    background-color: var(--color-bg-secondary);
+.breadcrumb-link:hover {
+    color: var(--primary-color);
 }
 
-.breadcrumb-home-icon {
-    width: 14px;
-    height: 14px;
-    margin-right: var(--space-1);
-    flex-shrink: 0;
-}
-
-.breadcrumb-separator {
-    margin: 0 var(--space-2);
-    color: var(--color-text-muted);
-    user-select: none;
-    font-weight: 400;
-}
-
-.breadcrumb-current {
-    color: var(--color-text-primary);
+.breadcrumb-item.active {
+    color: var(--text-primary);
     font-weight: 500;
-    max-width: 200px;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
 }
 
-/* Mobile Responsive */
+.sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+}
+
+/* Responsive adjustments */
 @media (max-width: 768px) {
     .breadcrumb-list {
-        font-size: var(--font-size-xs);
-        margin-bottom: var(--space-4);
-        padding: var(--space-2) 0;
+        font-size: 0.75rem;
     }
     
-    .breadcrumb-list a {
-        padding: var(--space-1);
-    }
-    
-    .breadcrumb-separator {
-        margin: 0 var(--space-1);
-    }
-    
-    .breadcrumb-current {
-        max-width: 150px;
-    }
-}
-
-@media (max-width: 480px) {
-    /* Hide intermediate levels on very small screens */
-    .breadcrumb-list li:nth-child(n+3):nth-last-child(n+3) {
-        display: none;
-    }
-    
-    .breadcrumb-list li:nth-child(n+3):nth-last-child(2) .breadcrumb-separator {
-        content: '···';
-    }
-}
-
-/* High contrast mode support */
-@media (prefers-contrast: high) {
-    .breadcrumb-list a {
-        text-decoration: underline;
-    }
-    
-    .breadcrumb-separator {
-        font-weight: bold;
-    }
-}
-
-/* Reduced motion support */
-@media (prefers-reduced-motion: reduce) {
-    .breadcrumb-list a {
-        transition: none;
+    .breadcrumb-item:not(:last-child)::after {
+        margin: 0 0.375rem;
     }
 }
 </style>

--- a/docs/_includes/page-navigation.html
+++ b/docs/_includes/page-navigation.html
@@ -1,40 +1,61 @@
 <!-- Page Navigation (Previous/Next) -->
-{% assign current_index = nil %}
-{% assign book_pages = site.pages | where: "layout", "book" %}
-{% assign all_pages = "" | split: "" %}
-{% for p in book_pages %}
-  {% assign page_order = p.order | default: 9999 %}
-  {% assign all_pages = all_pages | push: p %}
-{% endfor %}
-{% assign all_pages = all_pages | sort: 'order' %}
+<!-- Fallbacks to list-based navigation if per-page nav_data is unavailable -->
+{% assign current_path = page.url | remove: '.html' | remove_first: '/' %}
+{% assign previous_page = nil %}
+{% assign next_page = nil %}
 
-<!-- Find current page index -->
-{% for p in all_pages %}
-    {% if p.url == page.url %}
-        {% assign current_index = forloop.index0 %}
-        {% break %}
+{%- comment -%}
+Try BookGenerator-style per-page navigation first: site.data.navigation[<path>]
+{%- endcomment -%}
+{% assign nav_data = site.data.navigation[current_path] %}
+{% if nav_data %}
+  {% if nav_data.previous %}{% assign previous_page = nav_data.previous %}{% endif %}
+  {% if nav_data.next %}{% assign next_page = nav_data.next %}{% endif %}
+{% endif %}
+
+{%- comment -%}
+If previous/next not resolved, derive from list-based navigation
+{%- endcomment -%}
+{% if previous_page == nil and next_page == nil %}
+  {% assign items = "" | split: "" %}
+  {% if site.data.navigation.introduction %}
+    {% assign items = items | concat: site.data.navigation.introduction %}
+  {% endif %}
+  {% if site.data.navigation.chapters %}
+    {% assign items = items | concat: site.data.navigation.chapters %}
+  {% endif %}
+  {% if site.data.navigation.appendices %}
+    {% assign items = items | concat: site.data.navigation.appendices %}
+  {% endif %}
+  {% if site.data.navigation.afterword %}
+    {% assign items = items | concat: site.data.navigation.afterword %}
+  {% endif %}
+
+  {% assign current_index = -1 %}
+  {% for it in items %}
+    {% if page.url == it.path or page.url contains it.path %}
+      {% assign current_index = forloop.index0 %}
+      {% break %}
     {% endif %}
-{% endfor %}
+  {% endfor %}
 
-<!-- Calculate previous and next indices -->
-{% if current_index %}
+  {% if current_index != -1 %}
     {% assign prev_index = current_index | minus: 1 %}
     {% assign next_index = current_index | plus: 1 %}
-    
     {% if prev_index >= 0 %}
-        {% assign previous_page = all_pages[prev_index] %}
+      {% assign previous_page = items[prev_index] %}
     {% endif %}
-    
-    {% if next_index < all_pages.size %}
-        {% assign next_page = all_pages[next_index] %}
+    {% if next_index < items.size %}
+      {% assign next_page = items[next_index] %}
     {% endif %}
+  {% endif %}
 {% endif %}
 
 <div class="page-nav">
     <!-- Previous Page -->
     <div class="page-nav-item page-nav-prev">
         {% if previous_page %}
-        <a href="{{ previous_page.url | relative_url }}" class="page-nav-link">
+        <a href="{{ previous_page.path | relative_url }}" class="page-nav-link">
             <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
                 <polyline points="15 18 9 12 15 6"></polyline>
             </svg>
@@ -49,7 +70,7 @@
     <!-- Next Page -->
     <div class="page-nav-item page-nav-next">
         {% if next_page %}
-        <a href="{{ next_page.url | relative_url }}" class="page-nav-link">
+        <a href="{{ next_page.path | relative_url }}" class="page-nav-link">
             <div class="page-nav-content">
                 <span class="page-nav-label">次のページ</span>
                 <span class="page-nav-title">{{ next_page.title }}</span>


### PR DESCRIPTION
- page-navigation にフォールバック追加（必要時）\n- breadcrumb をv3テンプレートへ統一\n- 内部リンク（index.md/.html/.md）を pretty URL + relative_url に統一