### PR TITLE
docs: add bottom navigation to root

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -77,3 +77,5 @@ Email: [knowledge@itdo.jp](mailto:knowledge@itdo.jp)
 
 **📧 著者:** ITDO Inc. <knowledge@itdo.jp>  
 **📅 最終更新:** 2025年7月7日
+
+{% include page-navigation.html %}


### PR DESCRIPTION
Add bottom navigation include to docs/index.md so the root page shows prev/next/home controls.