### PR TITLE
chore: license metadata -> CC-BY-NC-SA-4.0

### DIFF
--- a/book-config.json
+++ b/book-config.json
@@ -4,7 +4,7 @@
   "author": "ITDO Inc.（株式会社アイティードゥ）",
   "version": "1.0.0",
   "language": "ja",
-  "license": "MIT",
+  "license": "CC BY-NC-SA 4.0",
   "repository": {
     "url": "https://github.com/itdojp/linux-infra-textbook.git",
     "branch": "main"

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
     "": {
       "name": "book-publishing-template-improved",
       "version": "2.0.0",
-      "license": "MIT",
+      "license": "CC-BY-NC-SA-4.0",
       "dependencies": {
         "fs-extra": "^11.3.0",
         "gray-matter": "^4.0.3"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "Linuxインフラ教本 - サーバー構築・運用の基礎",
   "author": "ITDO Inc.（株式会社アイティードゥ）",
-  "license": "MIT",
+  "license": "CC-BY-NC-SA-4.0",
   "engines": {
     "node": ">=18.0.0"
   },


### PR DESCRIPTION
シリーズ方針（CC BY-NC-SA 4.0、商用は別契約）に合わせて、リポジトリ内の license metadata 表記（MIT混入）を是正します。

変更ファイル:
- `book-config.json`
- `package-lock.json`
- `package.json`

補足: `package-lock.json` は root package の `license` のみを更新します（依存関係側の license は変更しません）。

関連: itdojp/it-engineer-knowledge-architecture#95