### PR TITLE
fix(docs): resolve broken internal links

### DIFF
--- a/INTEGRATION_CHECKLIST.md
+++ b/INTEGRATION_CHECKLIST.md
@@ -78,12 +78,12 @@ Your book description here.
 
 ## Quick Start
 
-Follow the [setup guide](setup-guide.md) to begin writing.
+Follow the [Quick Start](QUICK-START.md) to begin writing.
 ```
 
 ## 📚 Documentation References
 
-- [Setup Guide](setup-guide.md) - Complete installation and configuration
-- [Template Structure](template-structure.md) - Project organization  
-- [Troubleshooting Guide](TROUBLESHOOTING.md) - Common deployment issues
+- [Quick Start](QUICK-START.md) - Quick local development and preview setup
+- [Template Guide](book-template-guide.md) - Complete template guide (features, structure, workflows, and checklists)
+- [GitHub Pages Setup](GITHUB-PAGES-SETUP.md) - GitHub Pages deployment and setup
 - [Changelog](CHANGELOG.md) - Template updates and integration tracking

--- a/docs/chapters/chapter-02-basic-commands-exploration.md
+++ b/docs/chapters/chapter-02-basic-commands-exploration.md
@@ -453,4 +453,4 @@ SEE ALSO    - 関連コマンド
 
 ---
 
-**次章へ**: [第3章 ITインフラにおけるLinuxの役割](../chapter-03-linux-philosophy/)
+**次章へ**: [第3章 ITインフラにおけるLinuxの役割](chapter-03-linux-philosophy.md)

--- a/src/introduction/01-introduction.md
+++ b/src/introduction/01-introduction.md
@@ -18,4 +18,4 @@
 
 ## 次の章へ
 
-[第1章: 基本機能](../chapters/01-basic-features.md)に進みましょう。
+[第1章：ITインフラの全体像とLinuxの位置づけ](../chapters/chapter-01-linux-overview.md)に進みましょう。


### PR DESCRIPTION
目的: 内部リンクチェック（book-formatter/check-links）のbrokenを解消。

対応内容:
- INTEGRATION_CHECKLIST.md の存在しない参照を実在ドキュメントへ置換（QUICK-START.md / book-template-guide.md / GITHUB-PAGES-SETUP.md）
- src/introduction の「次の章へ」リンクを実在章へ修正（chapter-01-linux-overview.md）
- docs/chapters/chapter-02-basic-commands-exploration.md の次章リンクの相対パスを修正（../ -> 同一ディレクトリ）

確認:
- check-links: brokenLinks=0（book-formatter/scripts/check-links.js）

関連:
- https://github.com/itdojp/it-engineer-knowledge-architecture/issues/102
