### PR TITLE
fix(docs): fix code fence balance

### DIFF
--- a/docs/appendices/merged-exercise-answers.md
+++ b/docs/appendices/merged-exercise-answers.md
@@ -2834,6 +2834,8 @@ groups:
       - alert: HighErrorRate
         expr: rate(http_requests_total{status=~"5.."}[5m]) / rate(http_requests_total[5m]) > 0.05
         for: 5m
+```
+
 # 第14章 演習問題 解答集
 
 ## 問題1：基本理解の確認


### PR DESCRIPTION
## 概要（必須）

- 変更内容: Markdown のコードフェンス未クローズを修正し、以降のセクションがコードブロック扱いになるレイアウト崩れを防止

## 影響範囲（必須）

- 対象章/ページ（例: /path/to/page/）: `docs/appendices/merged-exercise-answers.md`
- 影響（例: 追記 / 構成変更 / リンク修正 / 図表修正）: 表示修正（コードフェンス終端の追加）

## QA（必須）

- [ ] Book QA（Unicode / textlint(PRH) / 内部リンク・アンカー / Jekyll build / built-site smoke）: PASS
  - 実行URL: （GitHub Actions の workflow run URL）

## Pages確認（原則必須）

- 確認URL: https://itdojp.github.io/linux-infra-textbook2/
- [ ] トップページ HTTP 200
- [ ] 主要導線（navigation.yml 相当）で 404 が無い
- [ ] 表示崩れが無い（図表/表/コード中心）

## 補足

- 既知の制約 / TODO: なし
