### PR TITLE
Amazon Linux 2023へ移行

### DIFF
--- a/docs/appendices/merged-exercise-answers.md
+++ b/docs/appendices/merged-exercise-answers.md
@@ -3756,7 +3756,8 @@ resource "aws_instance" "web" {
     #!/bin/bash
     dnf update -y
     dnf install -y nginx
-    echo "Web Server ${aws_instance.web.id}" > /usr/share/nginx/html/index.html
+    INSTANCE_ID=$(curl -s http://169.254.169.254/latest/meta-data/instance-id)
+    echo "Web Server $INSTANCE_ID" > /usr/share/nginx/html/index.html
     systemctl start nginx
     systemctl enable nginx
   EOF

--- a/docs/chapters/chapter-12-with-exercises.md
+++ b/docs/chapters/chapter-12-with-exercises.md
@@ -296,12 +296,17 @@ AWSとユーザーの責任範囲は明確に分かれています：
 #!/bin/bash
 # os_update.sh - 定期的なOSアップデート
 
-# Amazon Linux 2023の場合
-sudo dnf update -y
-
-# Ubuntu/Debianの場合
-sudo apt-get update
-sudo apt-get upgrade -y
+if command -v dnf >/dev/null 2>&1; then
+    # Amazon Linux 2023（dnf）
+    sudo dnf update -y
+elif command -v apt-get >/dev/null 2>&1; then
+    # Ubuntu/Debian（apt）
+    sudo apt-get update
+    sudo apt-get upgrade -y
+else
+    echo "Unsupported OS (no dnf/apt-get found)" >&2
+    exit 1
+fi
 
 # 再起動が必要な場合の判定
 if [ -f /var/run/reboot-required ]; then
@@ -354,6 +359,9 @@ REGION="ap-northeast-1"
 KEY_NAME="my-key"
 SECURITY_GROUP="my-sg"
 INSTANCE_TYPE="t3.micro"
+
+# 全コマンドで同一リージョンを使用
+export AWS_DEFAULT_REGION="$REGION"
 
 # 1. キーペアの作成（初回のみ）
 echo "Creating key pair..."

--- a/merged-exercise-answers.md
+++ b/merged-exercise-answers.md
@@ -3748,7 +3748,8 @@ resource "aws_instance" "web" {
     #!/bin/bash
     dnf update -y
     dnf install -y nginx
-    echo "Web Server ${aws_instance.web.id}" > /usr/share/nginx/html/index.html
+    INSTANCE_ID=$(curl -s http://169.254.169.254/latest/meta-data/instance-id)
+    echo "Web Server $INSTANCE_ID" > /usr/share/nginx/html/index.html
     systemctl start nginx
     systemctl enable nginx
   EOF

--- a/src/appendices/merged-exercise-answers.md
+++ b/src/appendices/merged-exercise-answers.md
@@ -3748,7 +3748,8 @@ resource "aws_instance" "web" {
     #!/bin/bash
     dnf update -y
     dnf install -y nginx
-    echo "Web Server ${aws_instance.web.id}" > /usr/share/nginx/html/index.html
+    INSTANCE_ID=$(curl -s http://169.254.169.254/latest/meta-data/instance-id)
+    echo "Web Server $INSTANCE_ID" > /usr/share/nginx/html/index.html
     systemctl start nginx
     systemctl enable nginx
   EOF

--- a/src/chapters/chapter-12-with-exercises.md
+++ b/src/chapters/chapter-12-with-exercises.md
@@ -298,12 +298,17 @@ AWSとユーザーの責任範囲は明確に分かれています：
 #!/bin/bash
 # os_update.sh - 定期的なOSアップデート
 
-# Amazon Linux 2023の場合
-sudo dnf update -y
-
-# Ubuntu/Debianの場合
-sudo apt-get update
-sudo apt-get upgrade -y
+if command -v dnf >/dev/null 2>&1; then
+    # Amazon Linux 2023（dnf）
+    sudo dnf update -y
+elif command -v apt-get >/dev/null 2>&1; then
+    # Ubuntu/Debian（apt）
+    sudo apt-get update
+    sudo apt-get upgrade -y
+else
+    echo "Unsupported OS (no dnf/apt-get found)" >&2
+    exit 1
+fi
 
 # 再起動が必要な場合の判定
 if [ -f /var/run/reboot-required ]; then
@@ -356,6 +361,9 @@ REGION="ap-northeast-1"
 KEY_NAME="my-key"
 SECURITY_GROUP="my-sg"
 INSTANCE_TYPE="t3.micro"
+
+# 全コマンドで同一リージョンを使用
+export AWS_DEFAULT_REGION="$REGION"
 
 # 1. キーペアの作成（初回のみ）
 echo "Creating key pair..."


### PR DESCRIPTION
Amazon Linux 2 前提の記述を Amazon Linux 2023 に更新しました。\n\n- OSアップデート例: yum -> dnf\n- EC2演習: AMI取得を SSM Public Parameter（al2023-ami-kernel-default-x86_64）参照に変更\n- Systems ManagerのPatch Baseline: operating-system を AMAZON_LINUX_2023 に更新\n- 演習解答集: Amazon Linux 2023 前提に更新