### PR TITLE
docs: Ubuntu installer URL を jammy(22.04) に更新

### DIFF
--- a/docs/chapters/chapter-09-container-evolution.md
+++ b/docs/chapters/chapter-09-container-evolution.md
@@ -50,7 +50,7 @@ $ sudo virt-install \
     --network bridge=br0 \
     --graphics none \
     --console pty,target_type=serial \
-    --location 'http://archive.ubuntu.com/ubuntu/dists/jammy/main/installer-amd64/'
+    --location 'https://archive.ubuntu.com/ubuntu/dists/jammy/main/installer-amd64/'
 ```
 
 ### 仮想マシンの限界

--- a/src/chapters/chapter-09-container-evolution.md
+++ b/src/chapters/chapter-09-container-evolution.md
@@ -56,7 +56,7 @@ $ sudo virt-install \
     --network bridge=br0 \
     --graphics none \
     --console pty,target_type=serial \
-    --location 'http://archive.ubuntu.com/ubuntu/dists/jammy/main/installer-amd64/'
+    --location 'https://archive.ubuntu.com/ubuntu/dists/jammy/main/installer-amd64/'
 ```
 
 ### 仮想マシンの限界


### PR DESCRIPTION
## 変更内容
- `virt-install` の例で参照している Ubuntu インストーラのURLを `focal`（20.04）から `jammy`（22.04）へ更新
- `docs/` と `src/` の両方を同一内容に同期

## 背景
- 「Ubuntu 20.04 向け手順は削除して 22.04/24.04 のみ残す」方針に合わせ、20.04 固定の参照を除去
