### PR TITLE
GitHub Actions の記述例を v4 に更新

### DIFF
--- a/docs/appendices/merged-exercise-answers.md
+++ b/docs/appendices/merged-exercise-answers.md
@@ -3963,7 +3963,7 @@ jobs:
   format-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       
       - uses: hashicorp/setup-terraform@v2
         with:
@@ -3977,7 +3977,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: format-check
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       
       - uses: hashicorp/setup-terraform@v2
         with:
@@ -3995,7 +3995,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: validate
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       
       - name: Run Checkov
         uses: bridgecrewio/checkov-action@master
@@ -4013,7 +4013,7 @@ jobs:
     needs: security-scan
     if: github.event_name == 'pull_request'
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       
       - uses: hashicorp/setup-terraform@v2
         with:
@@ -4069,7 +4069,7 @@ jobs:
     environment:
       name: production
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       
       - uses: hashicorp/setup-terraform@v2
         with:

--- a/docs/chapters/chapter-15-infrastructure-as-code.md
+++ b/docs/chapters/chapter-15-infrastructure-as-code.md
@@ -269,7 +269,7 @@ jobs:
   terraform:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v1

--- a/merged-exercise-answers.md
+++ b/merged-exercise-answers.md
@@ -3955,7 +3955,7 @@ jobs:
   format-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       
       - uses: hashicorp/setup-terraform@v2
         with:
@@ -3969,7 +3969,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: format-check
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       
       - uses: hashicorp/setup-terraform@v2
         with:
@@ -3987,7 +3987,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: validate
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       
       - name: Run Checkov
         uses: bridgecrewio/checkov-action@master
@@ -4005,7 +4005,7 @@ jobs:
     needs: security-scan
     if: github.event_name == 'pull_request'
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       
       - uses: hashicorp/setup-terraform@v2
         with:
@@ -4061,7 +4061,7 @@ jobs:
     environment:
       name: production
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       
       - uses: hashicorp/setup-terraform@v2
         with:

--- a/src/appendices/merged-exercise-answers.md
+++ b/src/appendices/merged-exercise-answers.md
@@ -3955,7 +3955,7 @@ jobs:
   format-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       
       - uses: hashicorp/setup-terraform@v2
         with:
@@ -3969,7 +3969,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: format-check
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       
       - uses: hashicorp/setup-terraform@v2
         with:
@@ -3987,7 +3987,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: validate
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       
       - name: Run Checkov
         uses: bridgecrewio/checkov-action@master
@@ -4005,7 +4005,7 @@ jobs:
     needs: security-scan
     if: github.event_name == 'pull_request'
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       
       - uses: hashicorp/setup-terraform@v2
         with:
@@ -4061,7 +4061,7 @@ jobs:
     environment:
       name: production
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       
       - uses: hashicorp/setup-terraform@v2
         with:

--- a/src/chapters/chapter-15-infrastructure-as-code.md
+++ b/src/chapters/chapter-15-infrastructure-as-code.md
@@ -269,7 +269,7 @@ jobs:
   terraform:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v1


### PR DESCRIPTION
Issue #102 の残作業（非推奨記述の棚卸し）対応です。

- ドキュメント内の `actions/checkout@v2` / `actions/checkout@v3` を `actions/checkout@v4` に更新
- `src` / `docs` / `merged` の重複管理ファイルを同期更新