### PR TITLE
CI記述例の @master 参照をバージョンタグへ更新

### DIFF
--- a/docs/appendices/merged-exercise-answers.md
+++ b/docs/appendices/merged-exercise-answers.md
@@ -3998,7 +3998,7 @@ jobs:
       - uses: actions/checkout@v4
       
       - name: Run Checkov
-        uses: bridgecrewio/checkov-action@master
+        uses: bridgecrewio/checkov-action@v12.3080.0
         with:
           directory: terraform/
           framework: terraform

--- a/merged-exercise-answers.md
+++ b/merged-exercise-answers.md
@@ -3990,7 +3990,7 @@ jobs:
       - uses: actions/checkout@v4
       
       - name: Run Checkov
-        uses: bridgecrewio/checkov-action@master
+        uses: bridgecrewio/checkov-action@v12.3080.0
         with:
           directory: terraform/
           framework: terraform

--- a/src/appendices/merged-exercise-answers.md
+++ b/src/appendices/merged-exercise-answers.md
@@ -3990,7 +3990,7 @@ jobs:
       - uses: actions/checkout@v4
       
       - name: Run Checkov
-        uses: bridgecrewio/checkov-action@master
+        uses: bridgecrewio/checkov-action@v12.3080.0
         with:
           directory: terraform/
           framework: terraform


### PR DESCRIPTION
## 概要
- 書籍本文の GitHub Actions 記述例に残っている @master 参照を、明示バージョンタグへ更新

## 変更内容
- bridgecrewio/checkov-action@master -> bridgecrewio/checkov-action@v12.3080.0

## 補足
- 本PRは、当該リポジトリに実在する該当記述のみを更新しています。
- Issue: https://github.com/itdojp/it-engineer-knowledge-architecture/issues/102