### PR TITLE
CI記述例の Terraform/AWS Actions 参照を更新

### DIFF
--- a/docs/appendices/merged-exercise-answers.md
+++ b/docs/appendices/merged-exercise-answers.md
@@ -3965,7 +3965,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       
-      - uses: hashicorp/setup-terraform@v2
+      - uses: hashicorp/setup-terraform@v3
         with:
           terraform_version: ${{ env.TF_VERSION }}
       
@@ -3979,7 +3979,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       
-      - uses: hashicorp/setup-terraform@v2
+      - uses: hashicorp/setup-terraform@v3
         with:
           terraform_version: ${{ env.TF_VERSION }}
       
@@ -4015,12 +4015,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       
-      - uses: hashicorp/setup-terraform@v2
+      - uses: hashicorp/setup-terraform@v3
         with:
           terraform_version: ${{ env.TF_VERSION }}
       
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v2
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -4071,12 +4071,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       
-      - uses: hashicorp/setup-terraform@v2
+      - uses: hashicorp/setup-terraform@v3
         with:
           terraform_version: ${{ env.TF_VERSION }}
       
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v2
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/docs/chapters/chapter-15-infrastructure-as-code.md
+++ b/docs/chapters/chapter-15-infrastructure-as-code.md
@@ -272,7 +272,7 @@ jobs:
       - uses: actions/checkout@v4
       
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v1
+        uses: hashicorp/setup-terraform@v3
       
       - name: Terraform Format Check
         run: terraform fmt -check -recursive

--- a/merged-exercise-answers.md
+++ b/merged-exercise-answers.md
@@ -3957,7 +3957,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       
-      - uses: hashicorp/setup-terraform@v2
+      - uses: hashicorp/setup-terraform@v3
         with:
           terraform_version: ${{ env.TF_VERSION }}
       
@@ -3971,7 +3971,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       
-      - uses: hashicorp/setup-terraform@v2
+      - uses: hashicorp/setup-terraform@v3
         with:
           terraform_version: ${{ env.TF_VERSION }}
       
@@ -4007,12 +4007,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       
-      - uses: hashicorp/setup-terraform@v2
+      - uses: hashicorp/setup-terraform@v3
         with:
           terraform_version: ${{ env.TF_VERSION }}
       
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v2
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -4063,12 +4063,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       
-      - uses: hashicorp/setup-terraform@v2
+      - uses: hashicorp/setup-terraform@v3
         with:
           terraform_version: ${{ env.TF_VERSION }}
       
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v2
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/src/appendices/merged-exercise-answers.md
+++ b/src/appendices/merged-exercise-answers.md
@@ -3957,7 +3957,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       
-      - uses: hashicorp/setup-terraform@v2
+      - uses: hashicorp/setup-terraform@v3
         with:
           terraform_version: ${{ env.TF_VERSION }}
       
@@ -3971,7 +3971,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       
-      - uses: hashicorp/setup-terraform@v2
+      - uses: hashicorp/setup-terraform@v3
         with:
           terraform_version: ${{ env.TF_VERSION }}
       
@@ -4007,12 +4007,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       
-      - uses: hashicorp/setup-terraform@v2
+      - uses: hashicorp/setup-terraform@v3
         with:
           terraform_version: ${{ env.TF_VERSION }}
       
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v2
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -4063,12 +4063,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       
-      - uses: hashicorp/setup-terraform@v2
+      - uses: hashicorp/setup-terraform@v3
         with:
           terraform_version: ${{ env.TF_VERSION }}
       
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v2
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/src/chapters/chapter-15-infrastructure-as-code.md
+++ b/src/chapters/chapter-15-infrastructure-as-code.md
@@ -272,7 +272,7 @@ jobs:
       - uses: actions/checkout@v4
       
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v1
+        uses: hashicorp/setup-terraform@v3
       
       - name: Terraform Format Check
         run: terraform fmt -check -recursive


### PR DESCRIPTION
## 概要
- 書籍本文の Terraform/AWS 関連 GitHub Actions 記述例で、旧参照を更新

## 変更内容
- `hashicorp/setup-terraform@v1|v2` -> `hashicorp/setup-terraform@v3`
- `aws-actions/configure-aws-credentials@v2` -> `aws-actions/configure-aws-credentials@v4`

## 補足
- 本PRは当該リポジトリに実在する記述のみ更新
- Issue: https://github.com/itdojp/it-engineer-knowledge-architecture/issues/102