### PR TITLE
docs: actions/setup-node を v6 に更新

### DIFF
--- a/book-template-guide.md
+++ b/book-template-guide.md
@@ -78,7 +78,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20'
           cache: 'npm'

--- a/templates/github-workflows/build-actions.yml
+++ b/templates/github-workflows/build-actions.yml
@@ -25,7 +25,7 @@ jobs:
       uses: actions/checkout@v4
       
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version: '20'
         cache: 'npm'

--- a/templates/github-workflows/build-legacy.yml
+++ b/templates/github-workflows/build-legacy.yml
@@ -19,7 +19,7 @@ jobs:
       uses: actions/checkout@v4
       
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version: '20'
         cache: 'npm'


### PR DESCRIPTION
- template guide / templates の workflow 例で `actions/setup-node@v4` を `@v6` に更新
- 変更範囲はドキュメント・テンプレート例のみ

関連: https://github.com/itdojp/it-engineer-knowledge-architecture/issues/102