### PR TITLE
ci: actions/setup-node を v6 に更新（book-qa）

### DIFF
--- a/.github/workflows/book-qa.yml
+++ b/.github/workflows/book-qa.yml
@@ -24,7 +24,7 @@ jobs:
           path: book-formatter
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20'
           cache: npm


### PR DESCRIPTION
## 概要
- `.github/workflows/book-qa.yml` に残っていた `actions/setup-node@v4` を `@v6` に更新
- Book QA workflow の Node setup action を最新メジャーに統一

Closes #102