### PR TITLE
docs: DESIGN-PREVIEW の不達リンクを更新

### DIFF
--- a/DESIGN-PREVIEW.md
+++ b/DESIGN-PREVIEW.md
@@ -14,7 +14,7 @@
 3. 右上の🌙/☀️ボタンでテーマ切り替えを試す
 
 ### オプション2: ローカルファイル
-1. [design-preview.html](./design-preview.html) を右クリック
+1. [design-preview.html](./design-preview.html?raw=1) を右クリック
 2. "名前を付けてリンク先を保存" を選択
 3. ダウンロードしたHTMLファイルをブラウザで開く
 


### PR DESCRIPTION
## 概要
- `DESIGN-PREVIEW.md` に残っていた不達リンク（404）を更新
- 旧 `book-publishing-template2` の生ファイル/Issue固定/templates固定リンクを、到達可能なURLへ置換

## 変更内容
- `design-preview.html` の raw URL を当該書籍リポジトリの `main` へ更新
- clone 先を当該書籍リポジトリへ更新
- フィードバック導線を `book-formatter` の Issues へ更新
- ソースコード参照を当該書籍リポジトリの `design-preview.html` へ更新
- テンプレート参照を `book-formatter` の templates へ更新

Closes #102