### PR TITLE
fix(docs): update Terraform Lambda runtime example to python3.12

### DIFF
--- a/docs/appendices/merged-exercise-answers.md
+++ b/docs/appendices/merged-exercise-answers.md
@@ -4271,7 +4271,7 @@ resource "aws_lambda_function" "dr_failover" {
   function_name = "dr-failover-automation"
   role          = aws_iam_role.lambda.arn
   handler       = "index.handler"
-  runtime       = "python3.9"
+  runtime       = "python3.12"
   
   environment {
     variables = {

--- a/merged-exercise-answers.md
+++ b/merged-exercise-answers.md
@@ -4263,7 +4263,7 @@ resource "aws_lambda_function" "dr_failover" {
   function_name = "dr-failover-automation"
   role          = aws_iam_role.lambda.arn
   handler       = "index.handler"
-  runtime       = "python3.9"
+  runtime       = "python3.12"
   
   environment {
     variables = {

--- a/src/appendices/merged-exercise-answers.md
+++ b/src/appendices/merged-exercise-answers.md
@@ -4263,7 +4263,7 @@ resource "aws_lambda_function" "dr_failover" {
   function_name = "dr-failover-automation"
   role          = aws_iam_role.lambda.arn
   handler       = "index.handler"
-  runtime       = "python3.9"
+  runtime       = "python3.12"
   
   environment {
     variables = {


### PR DESCRIPTION
## 概要
- Terraform の Lambda 例で残っていた `python3.9` を `python3.12` に更新しました。
- `src/`・`docs/`・ルート集約ファイルを同時に修正しています。

## 背景
- Python 3.9 は 2025-10 に upstream EOL です。
- AWS Lambda のランタイム例を AL2023 世代へ寄せ、EOLランタイム記述を排除します。

## 変更ファイル
- `src/appendices/merged-exercise-answers.md`
- `docs/appendices/merged-exercise-answers.md`
- `merged-exercise-answers.md`

## 関連
- itdojp/it-engineer-knowledge-architecture#102
