### PR TITLE
[codex] Fix broken chapter 9 image path

### DIFF
--- a/docs/chapters/chapter-09-container-evolution.md
+++ b/docs/chapters/chapter-09-container-evolution.md
@@ -61,7 +61,7 @@ $ sudo virt-install \
 
 ### 仮想マシンの限界
 
-![仮想マシンの限界](../../docs/assets/images/diagrams/chapter-09/vm-limitations.svg)
+![仮想マシンの限界]({{ '/assets/images/diagrams/chapter-09/vm-limitations.svg' | relative_url }})
 
 **問題点**：
 - 各VMに完全なOSが必要（メモリ・ディスク消費）

--- a/src/chapters/chapter-09-container-evolution.md
+++ b/src/chapters/chapter-09-container-evolution.md
@@ -61,7 +61,7 @@ $ sudo virt-install \
 
 ### 仮想マシンの限界
 
-![仮想マシンの限界](../../docs/assets/images/diagrams/chapter-09/vm-limitations.svg)
+![仮想マシンの限界]({{ '/assets/images/diagrams/chapter-09/vm-limitations.svg' | relative_url }})
 
 **問題点**：
 - 各VMに完全なOSが必要（メモリ・ディスク消費）


### PR DESCRIPTION
what changed
- fixed the chapter 9 image path in both `src` and generated `docs`
- replaced the broken `../../docs/assets/...` reference with the standard `relative_url` asset path

why it changed
- the previous relative path breaks on the published site because `_site/chapters/...` cannot resolve `../../docs/assets/...`
- this is a low-risk content fix that restores the diagram on the public page

impact
- chapter 9 renders the diagram correctly on GitHub Pages
- source and published markdown stay in sync

validation
- `git diff --check`
- `cd docs && bundle exec jekyll build`
- `node ../book-formatter/scripts/check-links.js docs`
- `node ../book-formatter/scripts/check-markdown-structure.js docs --fail-on error`
