### PR TITLE
[codex] Use PR list label on linux infra textbook 2 top page

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -113,7 +113,7 @@ permalink: /
 ## 利用と更新情報
 
 - リポジトリ: [itdojp/linux-infra-textbook2](https://github.com/itdojp/linux-infra-textbook2)
-- 更新差分を追う場合は、GitHub のコミット履歴と Pull Request を参照してください。
+- 更新差分を追う場合は、GitHub のコミット履歴と PR 一覧 を参照してください。
 - ディストリビューションやクラウドの仕様差がある箇所は、検証環境のバージョンと公式ドキュメントを併せて確認してください。
 
 ## 関連書籍


### PR DESCRIPTION
## What changed
- update the top-page change-tracking label from Pull Request(s) to PR 一覧

## Why
- align reader-facing wording with the other books in this series

## Validation
- `git diff --check`
- `cd docs && bundle exec jekyll build --source . --destination ../_site && cd .. && node /home/devuser/work/CodeX/booksB/repos/book-formatter/scripts/check-links.js docs && node /home/devuser/work/CodeX/booksB/repos/book-formatter/scripts/check-markdown-structure.js docs --fail-on error`
