### PR TITLE
[codex] Linuxインフラ演習の検証・レビューゲートを明確化する

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,5 @@
+# Pull Request
+
 ## 概要（必須）
 
 - 変更内容:
@@ -12,9 +14,17 @@
 - [ ] Book QA（Unicode / textlint(PRH) / 内部リンク・アンカー / Jekyll build / built-site smoke）: PASS
   - 実行URL:
 
+## Review Completion Gate（必須）
+
+- [ ] GitHub Copilot review を依頼した
+- [ ] review 本文・inline comment・suggestion を全件確認した
+- [ ] 必要な修正または変更不要理由を返信した
+- [ ] 未解決 review thread が 0 件であることを確認した
+- [ ] merge 後 main checks と公開サイト反映を確認する予定を Issue / PR body に記録した
+
 ## Pages確認（原則必須）
 
-- 確認URL: https://itdojp.github.io/linux-infra-textbook2/
+- 確認URL: <https://itdojp.github.io/linux-infra-textbook2/>
 - [ ] トップページ HTTP 200
 - [ ] 主要導線（navigation.yml 相当）で 404 が無い
 - [ ] 表示崩れが無い（図表/表/コード中心）

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,9 @@ node_modules/
 docs/_site/
 docs/.jekyll-cache/
 docs/.jekyll-metadata
+# Terraform local plan artifacts may contain sensitive values
+*.tfplan
+tfplan
+tfplan.sha256
+plan.tfplan
+plan.tfplan.sha256

--- a/docs/chapters/chapter-15-infrastructure-as-code.md
+++ b/docs/chapters/chapter-15-infrastructure-as-code.md
@@ -28,6 +28,7 @@
 > `terraform apply` は実クラウドリソース、課金、ネットワーク到達性、IAM 権限に影響します。
 > 演習では検証専用 workspace / state backend / AWS profile を用い、`terraform plan` の差分、destroy / replace の有無、予想コスト、ロールバック手順を確認してから適用します。
 > 共有環境や本番相当環境では、`-auto-approve` を標準手順にせず、PR review、承認、短期認証情報、state lock、適用後の smoke check を必須ゲートにします。
+> `tfplan` には変数、data source の戻り値、リソース属性などの機微情報が含まれる場合があるため、repository へ commit したり公開 Issue / PR に添付したりしません。
 
 ```bash
 terraform plan -out=tfplan

--- a/docs/chapters/chapter-15-infrastructure-as-code.md
+++ b/docs/chapters/chapter-15-infrastructure-as-code.md
@@ -23,13 +23,22 @@
 
 しかし今は違います。
 
+> 実行前ゲート
+>
+> `terraform apply` は実クラウドリソース、課金、ネットワーク到達性、IAM 権限に影響します。
+> 演習では検証専用 workspace / state backend / AWS profile を用い、`terraform plan` の差分、destroy / replace の有無、予想コスト、ロールバック手順を確認してから適用します。
+> 共有環境や本番相当環境では、`-auto-approve` を標準手順にせず、PR review、承認、短期認証情報、state lock、適用後の smoke check を必須ゲートにします。
+
 ```bash
 terraform plan -out=tfplan
-# review
+terraform show -no-color tfplan | less
+sha256sum tfplan > tfplan.sha256
+# 差分、削除/置換、課金、認証主体、対象 workspace を review 後に適用
 terraform apply tfplan
 ```
 
-たった数ステップで、複雑なインフラストラクチャを review 可能かつ再現可能な形で構築できます。これがInfrastructure as Code（IaC）の世界です。
+たった数ステップに見えても、実際には plan の差分確認、承認、適用、適用後確認までを含めて運用します。
+複雑なインフラストラクチャを review 可能かつ再現可能な形で構築できることが、Infrastructure as Code（IaC）の価値です。
 
 ## 15.2 手作業の限界と人的ミスの排除
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -38,6 +38,39 @@ permalink: /
 - ディストリビューションやバージョンによって、利用できるパッケージ、サービス管理方法、ネットワーク診断コマンドが異なる場合があります。
 - クラウド関連の章や自動化の章では、権限、課金、削除対象、適用範囲を事前に確認してください。
 
+## 検証環境とレビューゲート（2026年5月23日確認）
+
+本書のコマンド例は、Ubuntu LTS 系を含む systemd 前提の Linux 環境で学ぶことを想定します。
+Ubuntu の公式リリース一覧では、2026年4月23日に Ubuntu 26.04 LTS が公開され、22.04 LTS / 24.04 LTS / 26.04 LTS がいずれもサポート対象に含まれています。
+本文中の表示例やパッケージ名はディストリビューション、カーネル、systemd、Podman、AWS CLI、Terraform のバージョンによって変わるため、演習前に次を記録してください。
+
+```bash
+cat /etc/os-release
+uname -a
+systemctl --version
+podman --version 2>/dev/null || true
+aws --version 2>/dev/null || true
+terraform version 2>/dev/null || true
+```
+
+| 操作の種類 | 例 | 実行前ゲート |
+| --- | --- | --- |
+| 読み取り中心 | `ls`, `cat`, `ip addr show`, `journalctl --since` | 検証環境の OS / kernel / tool version を記録する |
+| ローカル状態変更 | `sudo`, `systemctl`, `ip addr add`, `chmod`, `chown`, `dd` | disposable VM / container / network namespace を優先し、戻し方を確認する |
+| 外部サービス変更 | `aws ...`, `terraform apply`, DNS / routing / IAM 変更 | 検証専用 account / profile / region、課金上限、削除手順、認証主体を確認する |
+
+AWS 演習では、root ユーザーや長期アクセスキーの常用を避け、IAM Identity Center や `AssumeRole` による一時認証情報を優先します。
+実行前に `aws sts get-caller-identity`、`AWS_PROFILE`、`AWS_REGION` / `AWS_DEFAULT_REGION` を確認し、演習後は作成リソースと課金対象を削除します。
+IAM Identity Center は、AWS 公式の Prescriptive Guidance でも複数アカウントへの centrally managed access の推奨アプローチとして説明されています。
+
+本書へ改善 PR を出す場合は、Issue に確認範囲、変更判断、検証結果を残し、GitHub Copilot review の本文・inline comment・suggestion を全件確認します。
+未解決 review thread が 0 件、CI green、merge 後 main checks、公開サイト反映確認までを完了条件とします。
+
+参考:
+
+- [Ubuntu project documentation: List of current releases](https://documentation.ubuntu.com/project/release-team/list-of-releases/)
+- [AWS Prescriptive Guidance: AWS IAM Identity Center](https://docs.aws.amazon.com/prescriptive-guidance/latest/security-reference-architecture-identity-management/workforce-iam-identity-center.html)
+
 ## 所要時間
 
 - 通読: 約3.5〜5時間（本文量ベース概算。コードブロック除外、400〜600文字/分換算）
@@ -130,6 +163,6 @@ Email: [knowledge@itdo.jp](mailto:knowledge@itdo.jp)
 
 **著者:** ITDO Inc. <knowledge@itdo.jp>  
 **バージョン:** 1.0.1  
-**最終更新:** 2026年2月20日
+**最終更新:** 2026年5月23日
 
 {% include page-navigation.html %}

--- a/docs/index.md
+++ b/docs/index.md
@@ -61,6 +61,7 @@ terraform version 2>/dev/null || true
 
 AWS 演習では、root ユーザーや長期アクセスキーの常用を避け、IAM Identity Center や `AssumeRole` による一時認証情報を優先します。
 実行前に `aws sts get-caller-identity`、`AWS_PROFILE`、`AWS_REGION` / `AWS_DEFAULT_REGION` を確認し、演習後は作成リソースと課金対象を削除します。
+Issue / PR に検証結果を投稿する場合は、Account ID、ARN、hostname、public IP、内部 CIDR、profile 名など、組織や個人を特定し得る値をマスクします。
 IAM Identity Center は、AWS 公式の Prescriptive Guidance でも複数アカウントへの centrally managed access の推奨アプローチとして説明されています。
 
 本書へ改善 PR を出す場合は、Issue に確認範囲、変更判断、検証結果を残し、GitHub Copilot review の本文・inline comment・suggestion を全件確認します。


### PR DESCRIPTION
## 概要

Fixes #143

Linux インフラ学習で実行前に確認すべき検証環境、危険操作、外部サービス変更、PR review 完了ゲートを明確化します。

## 変更内容

- トップページに「検証環境とレビューゲート（2026年5月23日確認）」を追加
  - Ubuntu LTS 系の時点確認
  - `cat /etc/os-release` / `uname -a` / tool version 記録
  - 読み取り中心・ローカル状態変更・外部サービス変更の実行前ゲート
  - AWS 演習での IAM Identity Center / AssumeRole / profile / region / cleanup 確認
- 第15章 IaC 導入部の `terraform apply` 例を、plan 差分確認・hash 記録・review 後 apply の流れへ変更
- PR テンプレートに Review Completion Gate を追加

## 公式情報の確認日

- 2026-05-23（Asia/Tokyo）
- Ubuntu project documentation: List of current releases
- AWS Prescriptive Guidance: AWS IAM Identity Center

## 検証

- [x] `npm ci --no-audit --no-fund`
- [x] `git diff --check`
- [x] `bash scripts/check-docs-sanity.sh docs`
- [x] `npx markdownlint .github/PULL_REQUEST_TEMPLATE.md docs/index.md`
- [x] `npm run check-links`
- [x] `npm run build`
- [x] built-site marker smoke for top page and Chapter 15
- [x] book-formatter pinned checks（`da2a49e7d2dcd9e1fa885e910c458130fe8d73a4`）
  - `check-unicode.js`: pass
  - `check-textlint.js`: pass（`TMPDIR=/home/devuser/work/CodeX/booksB/.codex-local/tmp`）
  - `check-links.js`: pass
  - `check-layout-risk.js --fail-on error`: pass（warning: existing long code line in Chapter 15）
  - `check-markdown-structure.js --fail-on error`: pass（warning: existing code fence without language in appendix）

## 既知の制約

- `npm run lint` は既存 baseline で失敗します（例: Chapter 9 / 12 の heading/fence/line-length、appendix line-length）。本PRの変更範囲外です。

## Review Completion Gate

- [x] GitHub Copilot review を依頼した
- [x] review 本文・inline comment・suggestion を全件確認した
- [x] 必要な修正または変更不要理由を返信した
- [x] 未解決 review thread が 0 件であることを確認した
- [x] CI green を確認した
- [x] merge 後 main checks と公開サイト反映を確認した

