### PR TITLE
Fix mobile sidebar closed state

### DIFF
--- a/docs/assets/css/mobile-responsive.css
+++ b/docs/assets/css/mobile-responsive.css
@@ -53,8 +53,21 @@ html {
     background: var(--bg-primary);
     border-right: 1px solid var(--border-color);
     box-shadow: 2px 0 8px rgba(0, 0, 0, 0.15);
-    z-index: 1000;
-    transform: translateX(-100%);
+    /*
+     * Keep the mobile drawer above the backdrop (`.book-sidebar-overlay` is
+     * 950) but below the fixed header (`.book-header` is 1000). This also
+     * needs to stay important so the later desktop `.book-sidebar` z-index in
+     * main.css cannot drop the mobile drawer behind the overlay.
+     */
+    z-index: 999 !important;
+    /*
+     * main.css imports this file before declaring the default desktop sidebar
+     * transform. Keep the closed drawer state important so the later desktop
+     * `transform: translateX(0)` rule cannot leave the TOC covering content
+     * on mobile and tablet widths. The checked/open rule below is more
+     * specific and also important, so the menu button still opens it.
+     */
+    transform: translateX(-100%) !important;
     transition: transform 0.3s ease;
   }
 


### PR DESCRIPTION
## Summary
- Keep the mobile/tablet sidebar closed state off-canvas with an important transform so the later desktop `.book-sidebar { transform: translateX(0); }` rule in `main.css` cannot override it.
- Set the mobile drawer z-index to `999 !important`, above `.book-sidebar-overlay` (`950`) and below `.book-header` (`1000`).
- Scope: `docs/assets/css/mobile-responsive.css` only; GitHub Pages source is `main` `/docs`.

## Verification
- `npm ci`
- `npm run check:security`
- `npm test`
- `git diff --check`
- `BUNDLE_PATH=/home/devuser/work/CodeX/booksB/.codex-local/tmp/linux-infra-textbook2-bundle-path BUNDLE_APP_CONFIG=/home/devuser/work/CodeX/booksB/.codex-local/tmp/linux-infra-textbook2-bundle-config npm run build`
- Local visual checker: `books=1 pages=10 ok=10 warn=0 fail=0`
- Direct Playwright z-index probe: `/` and `/chapters/chapter-01-linux-overview/` at 480/768/820/1024/1280px; closed sidebar is off-canvas, opened drawer remains above overlay and below header, desktop layout remains unchanged.

## Portfolio issue
- Part of https://github.com/itdojp/it-engineer-knowledge-architecture/issues/168
