### PR TITLE
chore: configure-pagesをNode.js 24対応v6へ更新する

### DIFF
--- a/.github/workflows/book-qa.yml
+++ b/.github/workflows/book-qa.yml
@@ -89,7 +89,7 @@ jobs:
           path: ${{ runner.temp }}/layout-risk-report.json
           if-no-files-found: ignore
       - name: Setup Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@v6
 
       - name: Build (Jekyll; GitHub Pages compatible)
         uses: actions/jekyll-build-pages@v1


### PR DESCRIPTION
Updates active book-qa.yml from actions/configure-pages@v5 to Node.js 24-compatible @v6. No other workflow, input, permission, Jekyll contract, or content change.

Verification: final head 53c633c43a4892c780f48e61985bec6ad5f997d2; actionlint 1.7.12; npm ci; npm audit 0; repository tests; Jekyll build; git diff --check all passed. Active v5=0/v6=1. Legacy Pages main:/docs managed warning remains separated to parent.

Closes #152
Related: itdojp/it-engineer-knowledge-architecture#258
