### PR TITLE
ci: update audited book-formatter pin

### DIFF
--- a/.github/workflows/book-qa.yml
+++ b/.github/workflows/book-qa.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           repository: itdojp/book-formatter
-          ref: da2a49e7d2dcd9e1fa885e910c458130fe8d73a4
+          ref: 69eb5c12f5a750b65614bc9bbbc3d7abd5aa6f6c
           path: book-formatter
 
       - name: Setup Node.js


### PR DESCRIPTION
## Summary

- update only the active `itdojp/book-formatter` checkout pin
- replace vulnerable `da2a49e7d2dcd9e1fa885e910c458130fe8d73a4` with audited immutable `69eb5c12f5a750b65614bc9bbbc3d7abd5aa6f6c`
- keep book content, book dependencies, QA commands, thresholds, and build contract unchanged

## Verification

- `actionlint .github/workflows/book-qa.yml`
- `git diff --check`
- changed-file scope: `.github/workflows/book-qa.yml` only
- active old formatter SHA references: 0
- audited formatter revision: full/prod `npm audit` 0; consumer-facing checker/schema blobs unchanged
- repository-specific QA and Pages build are exercised by PR checks

Closes #154

Parent: itdojp/it-engineer-knowledge-architecture#266

