### PR TITLE
docs: GitLab CI例のterraform initを有効なYAMLへ修正する

### DIFF
--- a/docs/chapters/chapter-15-infrastructure-as-code.md
+++ b/docs/chapters/chapter-15-infrastructure-as-code.md
@@ -640,7 +640,8 @@ variables:
 
 before_script:
   - cd ${TF_ROOT}
-  - terraform init
+  - >-
+    terraform init
     -backend-config="bucket=terraform-state-bucket"
     -backend-config="key=${TF_STATE_NAME}/terraform.tfstate"
     -backend-config="region=ap-northeast-1"


### PR DESCRIPTION
## 変更概要

- 第15章のGitLab CI例で、`terraform init`と3つの`-backend-config`をYAML folded scalarによる単一shell commandへ修正
- pipeline全体、apply権限、runner、Terraform provider、build契約は変更しない

## 検証

- 対象fenced YAMLをPyYAML 6.0.2でparse
- `before_script`が2要素で、2番目に`terraform init`が1回、3つのbackend設定が各1回含まれることをassert
- Node 24 `npm ci` / `npm test` / `npm run build` / `npm audit --audit-level=high`（脆弱性0）
- pinned book-formatter `69eb5c12f5a750b65614bc9bbbc3d7abd5aa6f6c`
  - Unicode / textlint: 指摘0
  - Markdown structure / layout risk: error 0
  - 既存warningは`merged-exercise-answers.md:1867`のfence language 1件と、第15章597行の長文1件。今回の変更行ではなく、warningを増加させていない
- 生成root / 第15章をHTTP 200で確認し、GitLab CI・Terraform backend markerを確認

Closes #156
