### PR TITLE
docs: Terraform S3例のAWS provider前提を固定・検証する

### DIFF
--- a/docs/chapters/chapter-15-infrastructure-as-code.md
+++ b/docs/chapters/chapter-15-infrastructure-as-code.md
@@ -384,39 +384,29 @@ git show a1b2c3d
 
 #### コンプライアンス対応
 
+検証baseline（2026-07-21）: [Terraform v1.15.8](https://github.com/hashicorp/terraform/releases/tag/v1.15.8) / [AWS Provider v6.55.0](https://github.com/hashicorp/terraform-provider-aws/releases/tag/v6.55.0)。次のroot module例は検証版を正確に固定する。実プロジェクトでは`.terraform.lock.hcl`もversion管理し、更新時に`plan`を再確認する。
+
 ```hcl
 # ポリシーの強制
-resource "aws_s3_bucket" "data" {
-  bucket = "company-sensitive-data"
-  
-  # 暗号化を強制
-  server_side_encryption_configuration {
-    rule {
-      apply_server_side_encryption_by_default {
-        sse_algorithm = "AES256"
-      }
+terraform {
+  required_version = "= 1.15.8"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "= 6.55.0"
     }
   }
-  
-  # バージョニングを有効化
-  versioning {
-    enabled = true
-  }
-  
-  # ロギングを有効化
-  logging {
-    target_bucket = aws_s3_bucket.logs.id
-    target_prefix = "s3-access-logs/"
-  }
-  
-  # パブリックアクセスをブロック
-  public_access_block {
-    block_public_acls       = true
-    block_public_policy     = true
-    ignore_public_acls      = true
-    restrict_public_buckets = true
-  }
-  
+}
+
+variable "environment" {
+  description = "Deployment environment"
+  type        = string
+}
+
+resource "aws_s3_bucket" "data" {
+  bucket = "company-sensitive-data"
+
   # タグによる管理
   tags = {
     Environment = var.environment
@@ -424,6 +414,43 @@ resource "aws_s3_bucket" "data" {
     Owner       = "DataTeam"
     CreatedBy   = "Terraform"
   }
+}
+
+# 暗号化を強制
+resource "aws_s3_bucket_server_side_encryption_configuration" "data" {
+  bucket = aws_s3_bucket.data.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+# バージョニングを有効化
+resource "aws_s3_bucket_versioning" "data" {
+  bucket = aws_s3_bucket.data.id
+
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+# ロギングを有効化
+resource "aws_s3_bucket_logging" "data" {
+  bucket        = aws_s3_bucket.data.id
+  target_bucket = "company-sensitive-data-access-logs"
+  target_prefix = "s3-access-logs/"
+}
+
+# パブリックアクセスをブロック
+resource "aws_s3_bucket_public_access_block" "data" {
+  bucket = aws_s3_bucket.data.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
 }
 ```
 
@@ -476,10 +503,12 @@ instances=$(aws ec2 describe-instances \
 # 2. Terraformコードの生成
 cat > main.tf << 'TF'
 terraform {
+  required_version = "= 1.15.8"
+
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.0"
+      version = "= 6.55.0"
     }
   }
 }

--- a/docs/chapters/chapter-15-infrastructure-as-code.md
+++ b/docs/chapters/chapter-15-infrastructure-as-code.md
@@ -315,6 +315,8 @@ jobs:
 
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: 1.15.8
       
       - name: Terraform Format Check
         run: terraform fmt -check -recursive
@@ -553,6 +555,8 @@ EOF
 
 chmod +x import_existing_infra.sh
 ```
+
+このimport scriptもTerraform CLI 1.15.8を前提とする。実行前に`terraform version`で確認し、異なる場合はscriptを実行しない。
 
 注記: `terraform import` の直後は `terraform state list`、`terraform state show aws_instance.<name>`、`terraform plan` の順に確認し、state に取り込まれた実リソースとコード側の属性差分を切り分けてください。誤った ID や resource address を import した場合は、実リソースを消さずに `terraform state rm <address>` で state だけ巻き戻してからやり直す方が安全です。
 

--- a/docs/chapters/chapter-15-infrastructure-as-code.md
+++ b/docs/chapters/chapter-15-infrastructure-as-code.md
@@ -388,7 +388,14 @@ git show a1b2c3d
 
 検証baseline（2026-07-21）: [Terraform v1.15.8](https://github.com/hashicorp/terraform/releases/tag/v1.15.8) / [AWS Provider v6.55.0](https://github.com/hashicorp/terraform-provider-aws/releases/tag/v6.55.0)。次のroot module例は検証版を正確に固定する。実プロジェクトでは`.terraform.lock.hcl`もversion管理し、更新時に`plan`を再確認する。
 
-`data_bucket_name`には一意な作成先を指定する。`access_log_bucket_name`には、同じAWS account/Regionにあり、`logging.s3.amazonaws.com`へ`s3:PutObject`を許可済みの既存bucketを指定する（[AWS公式の配信権限](https://docs.aws.amazon.com/AmazonS3/latest/userguide/enable-server-access-logging.html)）。この例は配信先bucketとpolicyを作成しない。
+`data_bucket_name`には一意な作成先を指定する。`access_log_bucket_name`には、[AWS公式の配信条件](https://docs.aws.amazon.com/AmazonS3/latest/userguide/enable-server-access-logging.html)を満たす既存bucketを指定する。
+
+- sourceと同じAWS account/Regionに置く
+- `logging.s3.amazonaws.com`へ`s3:PutObject`をbucket policyで許可する
+- Server access logging、Object Lock、default retention、Requester Paysを有効にしない
+- default encryptionにはSSE-S3を使用する
+
+この例は配信先bucketとpolicyを作成しない。
 
 ```hcl
 # ポリシーの強制

--- a/docs/chapters/chapter-15-infrastructure-as-code.md
+++ b/docs/chapters/chapter-15-infrastructure-as-code.md
@@ -386,6 +386,8 @@ git show a1b2c3d
 
 検証baseline（2026-07-21）: [Terraform v1.15.8](https://github.com/hashicorp/terraform/releases/tag/v1.15.8) / [AWS Provider v6.55.0](https://github.com/hashicorp/terraform-provider-aws/releases/tag/v6.55.0)。次のroot module例は検証版を正確に固定する。実プロジェクトでは`.terraform.lock.hcl`もversion管理し、更新時に`plan`を再確認する。
 
+`data_bucket_name`には一意な作成先を指定する。`access_log_bucket_name`には、同じAWS account/Regionにあり、`logging.s3.amazonaws.com`へ`s3:PutObject`を許可済みの既存bucketを指定する（[AWS公式の配信権限](https://docs.aws.amazon.com/AmazonS3/latest/userguide/enable-server-access-logging.html)）。この例は配信先bucketとpolicyを作成しない。
+
 ```hcl
 # ポリシーの強制
 terraform {
@@ -404,8 +406,18 @@ variable "environment" {
   type        = string
 }
 
+variable "data_bucket_name" {
+  description = "Globally unique name for the data bucket"
+  type        = string
+}
+
+variable "access_log_bucket_name" {
+  description = "Existing same-account and same-Region bucket configured for S3 log delivery"
+  type        = string
+}
+
 resource "aws_s3_bucket" "data" {
-  bucket = "company-sensitive-data"
+  bucket = var.data_bucket_name
 
   # タグによる管理
   tags = {
@@ -439,7 +451,7 @@ resource "aws_s3_bucket_versioning" "data" {
 # ロギングを有効化
 resource "aws_s3_bucket_logging" "data" {
   bucket        = aws_s3_bucket.data.id
-  target_bucket = "company-sensitive-data-access-logs"
+  target_bucket = var.access_log_bucket_name
   target_prefix = "s3-access-logs/"
 }
 


### PR DESCRIPTION
## 変更概要

- 第15章のTerraform/AWS Provider検証snapshotを2026-07-21時点のTerraform `1.15.8` / AWS Provider `6.55.0`へ固定
- S3 compliance例をAWS Provider 6.55.0のseparate resourcesへ更新
  - `aws_s3_bucket_server_side_encryption_configuration`
  - `aws_s3_bucket_versioning`
  - `aws_s3_bucket_logging`
  - `aws_s3_bucket_public_access_block`
- 同章のimport例も同じCLI/provider baselineへ同期
- 公式release URLとlock file運用境界を明示

## 一次情報

- Terraform v1.15.8: https://github.com/hashicorp/terraform/releases/tag/v1.15.8
- AWS Provider v6.55.0: https://github.com/hashicorp/terraform-provider-aws/releases/tag/v6.55.0
- 確認日: 2026-07-21 JST

## Terraform検証

- 公式`terraform_1.15.8_SHA256SUMS`でLinux amd64 archiveを検証
- 本文S3 HCL 65行を抽出
- `terraform fmt -check -diff`: success
- `terraform init -backend=false -input=false`: success、HashiCorp署名のAWS Provider 6.55.0を選択
- `terraform validate`: valid
- lock fileのprovider version `6.55.0`をassert
- 章内provider宣言2箇所が`6.55.0`、CLI宣言2箇所が`1.15.8`で一致し、旧`~> 4.0`が0件であることを確認

## 書籍QA

- Node 24 `npm test` / `npm run build` / `npm audit`（脆弱性0）
- pinned book-formatter `69eb5c12f5a750b65614bc9bbbc3d7abd5aa6f6c`: Unicode/textlint指摘0、structure/layout error 0
- 既存warningは変更外のfence language 1件と長文1件で増加なし
- 生成root / 第15章HTTP 200、baseline・4 separate resource marker、旧`~> 4.0`不在を確認

## 対象外

第15章全面刷新、state backend運用、実AWSへのplan/apply、S3の業務設計変更、build/依存/workflow変更は含みません。

Closes #157
